### PR TITLE
feat : My Info Modify API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,8 @@ dependencies {
 
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
+
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/eumserver/domain/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/eumserver/domain/jwt/JwtTokenProvider.java
@@ -1,5 +1,6 @@
 package com.example.eumserver.domain.jwt;
 
+import com.example.eumserver.domain.model.Name;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
@@ -85,7 +86,7 @@ public class JwtTokenProvider {
                 .getBody();
 
         String email = claims.get(CLAIM_EMAIL, String.class);
-        String name = claims.get(CLAIM_NAME, String.class);
+        Name name = new Name(claims.get(CLAIM_NAME, String.class), "");
         Collection<? extends GrantedAuthority> authorities =
                 Arrays.stream(claims.get(CLAIM_AUTHORITIES).toString().split(DELIMITER))
                         .map(SimpleGrantedAuthority::new)

--- a/src/main/java/com/example/eumserver/domain/jwt/PrincipleDetails.java
+++ b/src/main/java/com/example/eumserver/domain/jwt/PrincipleDetails.java
@@ -1,5 +1,6 @@
 package com.example.eumserver.domain.jwt;
 
+import com.example.eumserver.domain.model.Name;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
@@ -13,7 +14,7 @@ import java.util.Map;
 public class PrincipleDetails implements OAuth2User {
 
     private String email;
-    private String name;
+    private Name name;
     private Collection<? extends GrantedAuthority> authorities;
 
     @Override
@@ -28,7 +29,7 @@ public class PrincipleDetails implements OAuth2User {
 
     @Override
     public String getName() {
-        return this.name;
+        return this.name.getFullName();
     }
 
 }

--- a/src/main/java/com/example/eumserver/domain/model/Name.java
+++ b/src/main/java/com/example/eumserver/domain/model/Name.java
@@ -1,0 +1,24 @@
+package com.example.eumserver.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+@Embeddable
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@ToString(of = {"first", "last"})
+public class Name {
+
+    @Column(name = "first_name")
+    private String first;
+
+    @Column(name = "last_name")
+    private String last;
+
+    public String getFullName() {
+        return String.format("%s %s", this.first, this.last);
+    }
+}

--- a/src/main/java/com/example/eumserver/domain/model/Name.java
+++ b/src/main/java/com/example/eumserver/domain/model/Name.java
@@ -12,7 +12,7 @@ import lombok.*;
 @ToString(of = {"first", "last"})
 public class Name {
 
-    @Column(name = "first_name")
+    @Column(name = "first_name", nullable = false)
     private String first;
 
     @Column(name = "last_name")

--- a/src/main/java/com/example/eumserver/domain/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/eumserver/domain/oauth2/CustomOAuth2UserService.java
@@ -1,6 +1,7 @@
 package com.example.eumserver.domain.oauth2;
 
 import com.example.eumserver.domain.jwt.PrincipleDetails;
+import com.example.eumserver.domain.model.Name;
 import com.example.eumserver.domain.oauth2.attributes.OAuth2Attributes;
 import com.example.eumserver.domain.oauth2.attributes.OAuth2AttributesFactory;
 import com.example.eumserver.domain.user.User;
@@ -45,7 +46,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         return new PrincipleDetails(
                 oAuth2Attributes.getEmail(),
-                oAuth2Attributes.getName(),
+                new Name(oAuth2Attributes.getName(), ""),
                 Collections.singleton(new SimpleGrantedAuthority("ROLE_USER"))
         );
     }
@@ -53,7 +54,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private void registerUser(OAuth2Attributes oAuth2Attributes) {
         User user = User.builder()
                 .email(oAuth2Attributes.getEmail())
-                .name(oAuth2Attributes.getName())
+                .name(new Name(oAuth2Attributes.getName(), ""))
                 .avatar(oAuth2Attributes.getAvatar())
                 .provider(oAuth2Attributes.getProvider())
                 .providerId(oAuth2Attributes.getProviderId())

--- a/src/main/java/com/example/eumserver/domain/oauth2/attributes/GoogleOAuth2Attributes.java
+++ b/src/main/java/com/example/eumserver/domain/oauth2/attributes/GoogleOAuth2Attributes.java
@@ -1,5 +1,6 @@
 package com.example.eumserver.domain.oauth2.attributes;
 
+import com.example.eumserver.domain.model.Name;
 import lombok.Builder;
 
 import java.util.Map;

--- a/src/main/java/com/example/eumserver/domain/resume/Resume.java
+++ b/src/main/java/com/example/eumserver/domain/resume/Resume.java
@@ -1,0 +1,17 @@
+package com.example.eumserver.domain.resume;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "resumes")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Resume {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "resume_id")
+    private Long id;
+}

--- a/src/main/java/com/example/eumserver/domain/team/Team.java
+++ b/src/main/java/com/example/eumserver/domain/team/Team.java
@@ -1,0 +1,39 @@
+package com.example.eumserver.domain.team;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "users")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Team {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "team_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column
+    private String email;
+
+    @Column
+    private String logo;
+
+    @Column(name = "phone_number")
+    private String phoneNumber;
+
+    @CreationTimestamp
+    @Column(name = "formation_date", nullable = false, updatable = false)
+    private LocalDateTime formationDate;
+
+    @Column(columnDefinition = "TEXT")
+    private String introduction;
+}

--- a/src/main/java/com/example/eumserver/domain/team/Team.java
+++ b/src/main/java/com/example/eumserver/domain/team/Team.java
@@ -7,7 +7,7 @@ import org.hibernate.annotations.CreationTimestamp;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "users")
+@Table(name = "teams")
 @Getter
 @Builder
 @AllArgsConstructor

--- a/src/main/java/com/example/eumserver/domain/user/User.java
+++ b/src/main/java/com/example/eumserver/domain/user/User.java
@@ -1,5 +1,6 @@
 package com.example.eumserver.domain.user;
 
+import com.example.eumserver.domain.model.Name;
 import com.example.eumserver.domain.oauth2.attributes.OAuth2Attributes;
 import jakarta.persistence.*;
 import lombok.*;
@@ -27,7 +28,12 @@ public class User implements UserDetails {
   @Column(nullable = false, unique = true)
   private String email;
 
-  private String name;
+  @Embedded
+  @AttributeOverrides({
+          @AttributeOverride(name = "first", column = @Column(name = "first_name")),
+          @AttributeOverride(name = "last", column = @Column(name = "last_name"))
+  })
+  private Name name;
   private String avatar;
 
   @Builder.Default
@@ -41,7 +47,7 @@ public class User implements UserDetails {
 
   public void updateDefaultInfo(OAuth2Attributes OAuth2Attributes) {
     this.email = OAuth2Attributes.getEmail();
-    this.name = OAuth2Attributes.getName();
+    this.name = new Name(OAuth2Attributes.getName(), "");
     this.avatar = OAuth2Attributes.getAvatar();
   }
 

--- a/src/main/java/com/example/eumserver/domain/user/User.java
+++ b/src/main/java/com/example/eumserver/domain/user/User.java
@@ -4,10 +4,14 @@ import com.example.eumserver.domain.model.Name;
 import com.example.eumserver.domain.oauth2.attributes.OAuth2Attributes;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -34,7 +38,12 @@ public class User implements UserDetails {
           @AttributeOverride(name = "last", column = @Column(name = "last_name"))
   })
   private Name name;
+
+  @Column
   private String avatar;
+
+  @Column(name = "phone_number")
+  private String phoneNumber;
 
   @Builder.Default
   private String role = "ROLE_USER";
@@ -45,10 +54,32 @@ public class User implements UserDetails {
   @Column(nullable = false)
   private String providerId;
 
+  @Column(length =  4)
+  private String mbti;
+
+  @Column
+  private LocalDate birthday;
+
+  @CreationTimestamp
+  @Column(name = "create_date", nullable = false, updatable = false)
+  private LocalDateTime createDate;
+
+  @UpdateTimestamp
+  @Column(name = "update_at", nullable = false)
+  private LocalDateTime updateAt;
+
   public void updateDefaultInfo(OAuth2Attributes OAuth2Attributes) {
     this.email = OAuth2Attributes.getEmail();
     this.name = new Name(OAuth2Attributes.getName(), "");
     this.avatar = OAuth2Attributes.getAvatar();
+  }
+
+  public void updateProfile(Name name, String avatar, String phoneNumber, String mbti, LocalDate birthday){
+    this.name = name;
+    this.avatar = avatar;
+    this.phoneNumber = phoneNumber;
+    this.mbti = mbti;
+    this.birthday = birthday;
   }
 
   @Override

--- a/src/main/java/com/example/eumserver/domain/user/UserController.java
+++ b/src/main/java/com/example/eumserver/domain/user/UserController.java
@@ -29,7 +29,7 @@ public class UserController {
     @PutMapping("/me")
     public ResponseEntity<UserResponse> updateMyInfo(@AuthenticationPrincipal PrincipleDetails principleDetails, @RequestBody @Valid final UserUpdateRequest request){
         String email = principleDetails.getEmail();
-        User user = userService.findByEmail(email);
+        User user = userService.updateInfo(email, request);
         UserResponse userResponse = UserMapper.INSTANCE.userToUserResponse(user);
         return ResponseEntity.ok(userResponse);
     }

--- a/src/main/java/com/example/eumserver/domain/user/UserController.java
+++ b/src/main/java/com/example/eumserver/domain/user/UserController.java
@@ -1,6 +1,8 @@
 package com.example.eumserver.domain.user;
 
 import com.example.eumserver.domain.jwt.PrincipleDetails;
+import com.example.eumserver.domain.user.dto.UserResponse;
+import com.example.eumserver.domain.user.dto.UserUpdateRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -32,8 +34,10 @@ public class UserController {
         return ResponseEntity.ok(userResponse);
     }
 
-//    @GetMapping("/{id}")
-//    public ResponseEntity<UserResponse> getUserInfo(@PathVariable String id){
-//
-//    }
+    @GetMapping("/{email:.+}")
+    public ResponseEntity<UserResponse> getUserInfo(@PathVariable String email){
+        User user = userService.findByEmail(email);
+        UserResponse userResponse = UserMapper.INSTANCE.userToUserResponse(user);
+        return ResponseEntity.ok(userResponse);
+    }
 }

--- a/src/main/java/com/example/eumserver/domain/user/UserController.java
+++ b/src/main/java/com/example/eumserver/domain/user/UserController.java
@@ -25,14 +25,15 @@ public class UserController {
     }
 
     @PutMapping("/me")
-    public ResponseEntity<?> updateMyInfo(@AuthenticationPrincipal PrincipleDetails principleDetails, @RequestBody @Valid ){
+    public ResponseEntity<UserResponse> updateMyInfo(@AuthenticationPrincipal PrincipleDetails principleDetails, @RequestBody @Valid final UserUpdateRequest request){
         String email = principleDetails.getEmail();
         User user = userService.findByEmail(email);
-        return ResponseEntity.ok().body("Successfully information changed");
+        UserResponse userResponse = UserMapper.INSTANCE.userToUserResponse(user);
+        return ResponseEntity.ok(userResponse);
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<UserResponse> getUserInfo(@PathVariable String id){
-
-    }
+//    @GetMapping("/{id}")
+//    public ResponseEntity<UserResponse> getUserInfo(@PathVariable String id){
+//
+//    }
 }

--- a/src/main/java/com/example/eumserver/domain/user/UserController.java
+++ b/src/main/java/com/example/eumserver/domain/user/UserController.java
@@ -5,13 +5,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
 
 @Slf4j
 @RestController
-@RequestMapping("/users")
+@RequestMapping("/api/user")
 @RequiredArgsConstructor
 public class UserController {
 
@@ -25,4 +24,15 @@ public class UserController {
         return ResponseEntity.ok(userResponse);
     }
 
+    @PutMapping("/me")
+    public ResponseEntity<?> updateMyInfo(@AuthenticationPrincipal PrincipleDetails principleDetails, @RequestBody @Valid ){
+        String email = principleDetails.getEmail();
+        User user = userService.findByEmail(email);
+        return ResponseEntity.ok().body("Successfully information changed");
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<UserResponse> getUserInfo(@PathVariable String id){
+
+    }
 }

--- a/src/main/java/com/example/eumserver/domain/user/UserMapper.java
+++ b/src/main/java/com/example/eumserver/domain/user/UserMapper.java
@@ -11,6 +11,4 @@ public interface UserMapper {
     UserMapper INSTANCE = Mappers.getMapper(UserMapper.class);
 
     UserResponse userToUserResponse(User user);
-
-    UserUpdateRequest userUpdateRequestToUser(UserUpdateRequest userUpdateRequest);
 }

--- a/src/main/java/com/example/eumserver/domain/user/UserMapper.java
+++ b/src/main/java/com/example/eumserver/domain/user/UserMapper.java
@@ -1,5 +1,7 @@
 package com.example.eumserver.domain.user;
 
+import com.example.eumserver.domain.user.dto.UserResponse;
+import com.example.eumserver.domain.user.dto.UserUpdateRequest;
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
 

--- a/src/main/java/com/example/eumserver/domain/user/UserMapper.java
+++ b/src/main/java/com/example/eumserver/domain/user/UserMapper.java
@@ -9,4 +9,6 @@ public interface UserMapper {
     UserMapper INSTANCE = Mappers.getMapper(UserMapper.class);
 
     UserResponse userToUserResponse(User user);
+
+    UserUpdateRequest userUpdateRequestToUser(UserUpdateRequest userUpdateRequest);
 }

--- a/src/main/java/com/example/eumserver/domain/user/UserService.java
+++ b/src/main/java/com/example/eumserver/domain/user/UserService.java
@@ -17,6 +17,8 @@ public class UserService {
     }
 
     public User updateInfo(String email){
-        return userRepository.findByEmail(email).orElseThrow(() -> new CustomException(500, "User not found."));
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new CustomException(500, "User not found."));
+
+        return user;
     }
 }

--- a/src/main/java/com/example/eumserver/domain/user/UserService.java
+++ b/src/main/java/com/example/eumserver/domain/user/UserService.java
@@ -1,5 +1,7 @@
 package com.example.eumserver.domain.user;
 
+import com.example.eumserver.domain.model.Name;
+import com.example.eumserver.domain.user.dto.UserUpdateRequest;
 import com.example.eumserver.global.error.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,10 +18,11 @@ public class UserService {
         return userRepository.findByEmail(email).orElseThrow(() -> new CustomException(500, "User not found."));
     }
 
-    public User updateInfo(String email){
+    public User updateInfo(String email, UserUpdateRequest dto){
         User user = userRepository.findByEmail(email).orElseThrow(() -> new CustomException(500, "User not found."));
-
-
+        if(!dto.isValid(dto.mbti())) throw new CustomException(400, "Invalid Arguments");
+        user.updateProfile(new Name(dto.firstName(), dto.lastName()), dto.avatar(), dto.phoneNumber(),
+                    dto.mbti(), dto.birthday());
         return user;
     }
 }

--- a/src/main/java/com/example/eumserver/domain/user/UserService.java
+++ b/src/main/java/com/example/eumserver/domain/user/UserService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional(readOnly = true)
+@Transactional
 @RequiredArgsConstructor
 public class UserService {
 
@@ -18,6 +18,7 @@ public class UserService {
 
     public User updateInfo(String email){
         User user = userRepository.findByEmail(email).orElseThrow(() -> new CustomException(500, "User not found."));
+
 
         return user;
     }

--- a/src/main/java/com/example/eumserver/domain/user/UserService.java
+++ b/src/main/java/com/example/eumserver/domain/user/UserService.java
@@ -16,4 +16,7 @@ public class UserService {
         return userRepository.findByEmail(email).orElseThrow(() -> new CustomException(500, "User not found."));
     }
 
+    public User updateInfo(String email){
+        return userRepository.findByEmail(email).orElseThrow(() -> new CustomException(500, "User not found."));
+    }
 }

--- a/src/main/java/com/example/eumserver/domain/user/UserUpdateRequest.java
+++ b/src/main/java/com/example/eumserver/domain/user/UserUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.example.eumserver.domain.user;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
+
+public record UserUpdateRequest (
+        @Email String email,
+        @Pattern(regexp = "[0-9]{10,11}") String phoneNumber
+) {
+
+}

--- a/src/main/java/com/example/eumserver/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/example/eumserver/domain/user/dto/UserResponse.java
@@ -1,8 +1,10 @@
 package com.example.eumserver.domain.user.dto;
 
+import com.example.eumserver.domain.model.Name;
+
 public record UserResponse(
         String email,
-        String name,
+        Name name,
         String avatar
 ) {
 }

--- a/src/main/java/com/example/eumserver/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/example/eumserver/domain/user/dto/UserResponse.java
@@ -1,4 +1,4 @@
-package com.example.eumserver.domain.user;
+package com.example.eumserver.domain.user.dto;
 
 public record UserResponse(
         String email,

--- a/src/main/java/com/example/eumserver/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/example/eumserver/domain/user/dto/UserResponse.java
@@ -2,9 +2,14 @@ package com.example.eumserver.domain.user.dto;
 
 import com.example.eumserver.domain.model.Name;
 
+import java.time.LocalDate;
+
 public record UserResponse(
         String email,
         Name name,
-        String avatar
+        String avatar,
+        LocalDate birthday,
+        String mbti,
+        String phoneNumber
 ) {
 }

--- a/src/main/java/com/example/eumserver/domain/user/dto/UserUpdateRequest.java
+++ b/src/main/java/com/example/eumserver/domain/user/dto/UserUpdateRequest.java
@@ -1,4 +1,4 @@
-package com.example.eumserver.domain.user;
+package com.example.eumserver.domain.user.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Pattern;

--- a/src/main/java/com/example/eumserver/domain/user/dto/UserUpdateRequest.java
+++ b/src/main/java/com/example/eumserver/domain/user/dto/UserUpdateRequest.java
@@ -1,12 +1,30 @@
 package com.example.eumserver.domain.user.dto;
 
-import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
 
 public record UserUpdateRequest (
-        @Email String email,
+        @NotBlank String firstName,
+        String lastName,
+        String avatar,
+        LocalDate birthday,
+        @Size(min = 4, max = 4) String mbti,
         @Pattern(regexp = "[0-9]{10,11}") String phoneNumber
 
 ) {
+    private static final List<String> allowedMBTIs = Arrays.asList(
+            "INTJ", "INTP", "ENTJ", "ENTP",
+            "INFJ", "INFP", "ENFJ", "ENFP",
+            "ISTJ", "ISFJ", "ESTJ", "ESFJ",
+            "ISTP", "ISFP", "ESTP", "ESFP"
+    );
 
+    public boolean isValid(String mbti) {
+        return mbti == null || allowedMBTIs.contains(mbti.toUpperCase());
+    }
 }

--- a/src/main/java/com/example/eumserver/domain/user/dto/UserUpdateRequest.java
+++ b/src/main/java/com/example/eumserver/domain/user/dto/UserUpdateRequest.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.Pattern;
 public record UserUpdateRequest (
         @Email String email,
         @Pattern(regexp = "[0-9]{10,11}") String phoneNumber
+
 ) {
 
 }

--- a/src/main/java/com/example/eumserver/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/eumserver/global/config/SecurityConfig.java
@@ -46,8 +46,10 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
-
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/user/me").authenticated()
+                        .requestMatchers( "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/api/user/**").permitAll()
                         .anyRequest().authenticated())
                 .oauth2Login(oauth2 ->
                                 oauth2.userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig.userService(customOauth2UserService))

--- a/src/main/java/com/example/eumserver/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/eumserver/global/config/SwaggerConfig.java
@@ -1,0 +1,35 @@
+package com.example.eumserver.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        String jwt = "JWT";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwt);
+        Components components = new Components().addSecuritySchemes(jwt, new SecurityScheme()
+                .name(jwt)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+        );
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo())
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
+    private Info apiInfo() {
+        return new Info()
+                .title("E-UM API Docs")
+                .description("E-UM Project API Docs")
+                .version("1.0.0");
+    }
+}

--- a/src/test/java/com/example/eumserver/domain/user/UserApiTest.java
+++ b/src/test/java/com/example/eumserver/domain/user/UserApiTest.java
@@ -1,0 +1,4 @@
+package com.example.eumserver.domain.user;
+
+public class UserApiTest {
+}

--- a/src/test/java/com/example/eumserver/domain/user/UserApiTest.java
+++ b/src/test/java/com/example/eumserver/domain/user/UserApiTest.java
@@ -1,4 +1,0 @@
-package com.example.eumserver.domain.user;
-
-public class UserApiTest {
-}

--- a/src/test/java/com/example/eumserver/domain/user/UserControllerTest.java
+++ b/src/test/java/com/example/eumserver/domain/user/UserControllerTest.java
@@ -1,0 +1,25 @@
+package com.example.eumserver.domain.user;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserControllerTest {
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @Test
+    void getMyInfo() {
+    }
+
+    @Test
+    void updateMyInfo() {
+    }
+
+    @Test
+    void getUserInfo() {
+    }
+}


### PR DESCRIPTION
### Description

- 마이페이지 정보 수정 Api 추가
- 다른 유저 정보 받아오기 Api  추가
- Swagger 적용
- Team, Entity 추가

### Issue
#2 #3 

### Details

- Swagger 적용
   - 효율적인 API 문서 작성을 위해 Swagger 추가함
   - 아직 설명은 작성하지 않음

- 마이페이지 정보 수정 Api 추가
   - 기존 /users 엔드포인트를 /api/user로 변경
   - 따라서 내 정보 받아오기도 /api/user/me로 요청해야됨
   - 내 정보 수정은 [put] /api/user/me로 토큰과 함께 요청 보내면 됨
 
- User Entity 변경
    -  프론트가 만든거 보니깐 성, 이름 따로따로 받길래 Embeded로 각각 분리했습니다.
    - 이 과정에서 소셜 로그인 이름 받는 부분도 자료형 바꿨는데, 대충 하다보니 살짝 더러워 보일 수도..?

![image](https://github.com/Alpha-e-Um/Backend/assets/55117706/02835bef-1e1f-4314-b646-8ea7ecd77207) 
![image](https://github.com/Alpha-e-Um/Backend/assets/55117706/58d36915-3707-42b3-b8b5-776ff75a6652)
![image](https://github.com/Alpha-e-Um/Backend/assets/55117706/d1bd8fde-ae67-4e69-bb74-08d0c134f77b)

### Review
- PR 문서 탬플릿 요소에 대한 고민이 필요함. 해당 문서는 임의로 한번 써본긴 했음.
- Test 코드 작성 예정
- 프론트랑 연동 테스트 해볼 필요가 있음