### PR TITLE
refactor: 팀 공고 조회 로직 변경 및 필터를 쿼리 파라미터로 받기

### DIFF
--- a/business/src/main/java/com/example/eumserver/domain/announcement/resume/controller/ResumeAnnouncementController.java
+++ b/business/src/main/java/com/example/eumserver/domain/announcement/resume/controller/ResumeAnnouncementController.java
@@ -40,9 +40,10 @@ public class ResumeAnnouncementController {
     @GetMapping("")
     public ResponseEntity<ApiResult<Page<ResumeAnnouncementResponse>>> getResumeAnnouncements(
             @RequestBody ResumeAnnouncementFilter filter,
-            @RequestParam(name = "page", defaultValue = "0") int page
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "12") int size
     ) {
-        Page<ResumeAnnouncementResponse> resumeAnnouncementResponses = resumeAnnouncementService.getResumeAnnouncements(filter, page);
+        Page<ResumeAnnouncementResponse> resumeAnnouncementResponses = resumeAnnouncementService.getResumeAnnouncements(filter, page, size);
         return ResponseEntity.ok(new ApiResult<>("이력서 공고 필터링 및 페이징 조회 성공", resumeAnnouncementResponses));
     }
 }

--- a/business/src/main/java/com/example/eumserver/domain/announcement/resume/service/ResumeAnnouncementService.java
+++ b/business/src/main/java/com/example/eumserver/domain/announcement/resume/service/ResumeAnnouncementService.java
@@ -45,10 +45,10 @@ public class ResumeAnnouncementService {
         resumeAnnouncementRepository.delete(resumeAnnouncement);
     }
 
-    public Page<ResumeAnnouncementResponse> getResumeAnnouncements(ResumeAnnouncementFilter filter, int page) {
+    public Page<ResumeAnnouncementResponse> getResumeAnnouncements(ResumeAnnouncementFilter filter, int page, int size) {
         List<Sort.Order> sorts = new ArrayList<>();
         sorts.add(Sort.Order.desc("date_created"));
-        Pageable pageable = PageRequest.of(page, 12, Sort.by(sorts));
+        Pageable pageable = PageRequest.of(page, size, Sort.by(sorts));
         return resumeRepository.findResumeAnnouncementsWithFilteredAndPagination(filter, pageable);
     }
 }

--- a/business/src/main/java/com/example/eumserver/domain/announcement/team/controller/TeamAnnouncementController.java
+++ b/business/src/main/java/com/example/eumserver/domain/announcement/team/controller/TeamAnnouncementController.java
@@ -35,13 +35,17 @@ public class TeamAnnouncementController {
                 .body(new ApiResult<>("팀 공고 생성 성공", announcementResponse));
     }
 
+    /**
+     * 팀 공고를 필터에 따라 조회합니다.
+     * 어노테이션이 적용되어 있지 않지만, 쿼리 파라미터로 들어가게 됩니다.
+     * @param filter 팀 공고 필터
+     * @return 페이징이 적용된 팀 공고 리스트
+     */
     @GetMapping("")
     public ResponseEntity<ApiResult<Page<TeamAnnouncementResponse>>> getAnnouncements(
-            @RequestParam(name = "page", defaultValue = "0") int page,
-            @RequestParam(name = "size", defaultValue = "12") int size,
-            @RequestBody TeamAnnouncementFilter announcementFilter
+        TeamAnnouncementFilter filter
     ) {
-        Page<TeamAnnouncementResponse> filteredAnnouncementsWithPaging = announcementService.getFilteredAnnouncementsWithPaging(page, size, announcementFilter);
+        Page<TeamAnnouncementResponse> filteredAnnouncementsWithPaging = announcementService.getFilteredAnnouncementsWithPaging(filter);
         return ResponseEntity
                 .ok(new ApiResult<>("팀 공고 필터링 및 페이징 조회 성공", filteredAnnouncementsWithPaging));
     }

--- a/business/src/main/java/com/example/eumserver/domain/announcement/team/controller/TeamAnnouncementController.java
+++ b/business/src/main/java/com/example/eumserver/domain/announcement/team/controller/TeamAnnouncementController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
-@RequestMapping("/api/announcement")
+@RequestMapping("/api/team-announcement")
 @RequiredArgsConstructor
 public class TeamAnnouncementController {
 

--- a/business/src/main/java/com/example/eumserver/domain/announcement/team/controller/TeamAnnouncementController.java
+++ b/business/src/main/java/com/example/eumserver/domain/announcement/team/controller/TeamAnnouncementController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
-@RequestMapping("/api/team/{teamId}/announcement")
+@RequestMapping("/api/announcement")
 @RequiredArgsConstructor
 public class TeamAnnouncementController {
 
@@ -26,11 +26,10 @@ public class TeamAnnouncementController {
     @PostMapping("")
     @ResponseStatus(HttpStatus.CREATED)
     public ResponseEntity<ApiResult<TeamAnnouncementResponse>> createAnnouncement(
-            @PathVariable(name = "teamId") Long teamId,
             @RequestBody TeamAnnouncementRequest announcementRequest
     ) {
         log.debug("announcement request: {}", announcementRequest);
-        TeamAnnouncementResponse announcementResponse = announcementService.createAnnouncement(teamId, announcementRequest);
+        TeamAnnouncementResponse announcementResponse = announcementService.createAnnouncement(announcementRequest);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(new ApiResult<>("팀 공고 생성 성공", announcementResponse));
@@ -38,11 +37,11 @@ public class TeamAnnouncementController {
 
     @GetMapping("")
     public ResponseEntity<ApiResult<Page<TeamAnnouncementResponse>>> getAnnouncements(
-            @PathVariable(name = "teamId") Long teamId,
-            @RequestParam(name = "page", defaultValue = "0") Integer page,
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "12") int size,
             @RequestBody TeamAnnouncementFilter announcementFilter
     ) {
-        Page<TeamAnnouncementResponse> filteredAnnouncementsWithPaging = announcementService.getFilteredAnnouncementsWithPaging(teamId, page, announcementFilter);
+        Page<TeamAnnouncementResponse> filteredAnnouncementsWithPaging = announcementService.getFilteredAnnouncementsWithPaging(page, size, announcementFilter);
         return ResponseEntity
                 .ok(new ApiResult<>("팀 공고 필터링 및 페이징 조회 성공", filteredAnnouncementsWithPaging));
     }

--- a/business/src/main/java/com/example/eumserver/domain/announcement/team/dto/TeamAnnouncementFilter.java
+++ b/business/src/main/java/com/example/eumserver/domain/announcement/team/dto/TeamAnnouncementFilter.java
@@ -1,11 +1,22 @@
 package com.example.eumserver.domain.announcement.team.dto;
 
 import com.example.eumserver.domain.announcement.filter.domain.OccupationClassification;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.Data;
 
 import java.util.List;
 
-public record TeamAnnouncementFilter(
-        boolean published,
-        List<OccupationClassification> occupationClassifications
-) {
+@Data
+public class TeamAnnouncementFilter{
+    private final int page;
+    private final int size;
+    private final List<OccupationClassification> occupationClassifications;
+
+    public TeamAnnouncementFilter(int page, int size, List<String> occupationClassifications) {
+        this.page = page;
+        this.size = size;
+        this.occupationClassifications = occupationClassifications.stream().map(
+                OccupationClassification::from
+        ).toList();
+    }
 }

--- a/business/src/main/java/com/example/eumserver/domain/announcement/team/dto/TeamAnnouncementRequest.java
+++ b/business/src/main/java/com/example/eumserver/domain/announcement/team/dto/TeamAnnouncementRequest.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public record TeamAnnouncementRequest(
+        Long teamId,
         String title,
         String description,
         int vacancies,

--- a/business/src/main/java/com/example/eumserver/domain/announcement/team/repository/TeamAnnouncementCustomRepository.java
+++ b/business/src/main/java/com/example/eumserver/domain/announcement/team/repository/TeamAnnouncementCustomRepository.java
@@ -15,6 +15,6 @@ public interface TeamAnnouncementCustomRepository {
      * @param pageable Pagination information including page number, page size, and sort order.
      * @return A {@link Page} of {@link TeamAnnouncement} objects that match the specified filters.
      */
-    Page<TeamAnnouncementResponse> getFilteredAnnouncementsWithPaging(Long teamId, TeamAnnouncementFilter filter, Pageable pageable);
+    Page<TeamAnnouncementResponse> getFilteredAnnouncementsWithPaging(TeamAnnouncementFilter filter, Pageable pageable);
 
 }

--- a/business/src/main/java/com/example/eumserver/domain/announcement/team/repository/TeamAnnouncementCustomRepositoryImpl.java
+++ b/business/src/main/java/com/example/eumserver/domain/announcement/team/repository/TeamAnnouncementCustomRepositoryImpl.java
@@ -24,11 +24,9 @@ public class TeamAnnouncementCustomRepositoryImpl implements TeamAnnouncementCus
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<TeamAnnouncementResponse> getFilteredAnnouncementsWithPaging(Long teamId, TeamAnnouncementFilter filter, Pageable pageable) {
+    public Page<TeamAnnouncementResponse> getFilteredAnnouncementsWithPaging(TeamAnnouncementFilter filter, Pageable pageable) {
         QTeamAnnouncement teamAnnouncement = QTeamAnnouncement.teamAnnouncement;
         BooleanExpression predicate = teamAnnouncement.isNotNull();
-
-        predicate = predicate.and(teamAnnouncement.team.id.eq(teamId));
 
         if (filter.published()) {
             predicate = predicate.and(teamAnnouncement.publishedDate.isNotNull());

--- a/business/src/main/java/com/example/eumserver/domain/announcement/team/repository/TeamAnnouncementCustomRepositoryImpl.java
+++ b/business/src/main/java/com/example/eumserver/domain/announcement/team/repository/TeamAnnouncementCustomRepositoryImpl.java
@@ -27,12 +27,9 @@ public class TeamAnnouncementCustomRepositoryImpl implements TeamAnnouncementCus
     public Page<TeamAnnouncementResponse> getFilteredAnnouncementsWithPaging(TeamAnnouncementFilter filter, Pageable pageable) {
         QTeamAnnouncement teamAnnouncement = QTeamAnnouncement.teamAnnouncement;
         BooleanExpression predicate = teamAnnouncement.isNotNull();
+        predicate = predicate.and(teamAnnouncement.publishedDate.isNotNull());
 
-        if (filter.published()) {
-            predicate = predicate.and(teamAnnouncement.publishedDate.isNotNull());
-        }
-
-        List<OccupationClassification> occupationClassifications = filter.occupationClassifications();
+        List<OccupationClassification> occupationClassifications = filter.getOccupationClassifications();
         if (occupationClassifications != null && !occupationClassifications.isEmpty()) {
             predicate = predicate.and(teamAnnouncement.occupationClassifications.any().in(occupationClassifications));
         }

--- a/business/src/main/java/com/example/eumserver/domain/announcement/team/service/TeamAnnouncementService.java
+++ b/business/src/main/java/com/example/eumserver/domain/announcement/team/service/TeamAnnouncementService.java
@@ -33,19 +33,19 @@ public class TeamAnnouncementService {
     private final TeamService teamService;
 
     public Page<TeamAnnouncementResponse> getFilteredAnnouncementsWithPaging(
-            Long teamId,
             int page,
+            int size,
             TeamAnnouncementFilter filter
     ) {
         List<Sort.Order> sorts = new ArrayList<>();
         sorts.add(Sort.Order.desc("date_created"));
-        Pageable pageable = PageRequest.of(page, 12, Sort.by(sorts));
-        return announcementRepository.getFilteredAnnouncementsWithPaging(teamId, filter, pageable);
+        Pageable pageable = PageRequest.of(page, size, Sort.by(sorts));
+        return announcementRepository.getFilteredAnnouncementsWithPaging(filter, pageable);
     }
 
     @Transactional
-    public TeamAnnouncementResponse createAnnouncement(Long teamId, TeamAnnouncementRequest announcementRequest) {
-        Team team = teamService.findById(teamId);
+    public TeamAnnouncementResponse createAnnouncement(TeamAnnouncementRequest announcementRequest) {
+        Team team = teamService.findById(announcementRequest.teamId());
 
         TeamAnnouncement announcement = TeamAnnouncementMapper.INSTANCE.requestToEntity(announcementRequest);
         announcement.setTeam(team);

--- a/business/src/main/java/com/example/eumserver/domain/announcement/team/service/TeamAnnouncementService.java
+++ b/business/src/main/java/com/example/eumserver/domain/announcement/team/service/TeamAnnouncementService.java
@@ -33,13 +33,11 @@ public class TeamAnnouncementService {
     private final TeamService teamService;
 
     public Page<TeamAnnouncementResponse> getFilteredAnnouncementsWithPaging(
-            int page,
-            int size,
             TeamAnnouncementFilter filter
     ) {
         List<Sort.Order> sorts = new ArrayList<>();
         sorts.add(Sort.Order.desc("date_created"));
-        Pageable pageable = PageRequest.of(page, size, Sort.by(sorts));
+        Pageable pageable = PageRequest.of(filter.getPage(), filter.getSize(), Sort.by(sorts));
         return announcementRepository.getFilteredAnnouncementsWithPaging(filter, pageable);
     }
 

--- a/business/src/test/java/com/example/eumserver/domain/announcement/team/controller/TeamAnnouncementControllerTest.java
+++ b/business/src/test/java/com/example/eumserver/domain/announcement/team/controller/TeamAnnouncementControllerTest.java
@@ -15,6 +15,8 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -40,6 +42,7 @@ class TeamAnnouncementControllerTest extends BaseIntegrationTest {
 
         TeamAnnouncementRequest announcementRequest =
                 new TeamAnnouncementRequest(
+                        team.getId(),
                         "title",
                         "description",
                         5,
@@ -91,15 +94,19 @@ class TeamAnnouncementControllerTest extends BaseIntegrationTest {
         TeamAnnouncement announcement = createAnnouncement(team);
 
         TeamAnnouncementFilter filter = new TeamAnnouncementFilter(
-                false,
-                List.of(OccupationClassification.DEVELOPMENT_BACKEND, OccupationClassification.DEVELOPMENT_DEVOPS)
+                0,
+                10,
+                List.of("design_ui_ux")
         );
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("page", String.valueOf(filter.getPage()));
+        params.add("size", String.valueOf(filter.getSize()));
+        filter.getOccupationClassifications().forEach(oc -> params.add("occupationClassifications", oc.toString()));
 
         ResultActions resultActions = mockMvc.perform(
                 get(BASE_URI, team.getId())
-                        .param("page", "0")
-                        .content(objectMapper.writeValueAsString(filter))
-                        .contentType(MediaType.APPLICATION_JSON)
+                        .queryParams(params)
                         .accept(MediaType.APPLICATION_JSON)
         );
 


### PR DESCRIPTION
## Overview

팀 공고 조회가 팀 id를 통해서 팀에 속한 공고만 조회할 수 있었고, 이를 전체 공고 조회로 변환했습니다.
그리고 Get Method의 취지에 맞게 filter를 query parameter로 변경했습니다.

### Related Issue
Issue Number : #80 

## Task Details

- 팀 공고 URI 변경
- 팀 공고 조회를 전체 조회로 변경
- 필터를 쿼리파라미터로 받도록 변경

## Review Requirements
