### PR TITLE
fix-feat: 팀 로고 null일 때 처리 및 팀 로고 형식 및 용량 제한

### DIFF
--- a/business/src/main/java/com/example/eumserver/domain/team/TeamService.java
+++ b/business/src/main/java/com/example/eumserver/domain/team/TeamService.java
@@ -28,6 +28,8 @@ public class TeamService {
     private final ParticipantRepository participantRepository;
     private final S3Uploader s3Uploader;
 
+    private static final List<String> ALLOWED_MIME_TYPES = List.of("image/jpeg", "image/png");
+
     @Transactional
     public Team createTeam(
             long userId,
@@ -38,6 +40,12 @@ public class TeamService {
 
         Team team = TeamMapper.INSTANCE.teamRequestToTeam(teamRequest);
         if (logo != null) {
+            String contentType = logo.getContentType();
+            if (!ALLOWED_MIME_TYPES.contains(contentType)) {
+                throw new CustomException(
+                        ErrorCode.UNSUPPORTED_MEDIA_TYPE.getMessage() + " (허용된 형식: " + ALLOWED_MIME_TYPES + ")",
+                        ErrorCode.UNSUPPORTED_MEDIA_TYPE);
+            }
             String uploadUrl = s3Uploader.uploadToS3(S3Uploader.S3Path.TEAM_IMAGE, logo);
             team.setLogo(uploadUrl);
         }

--- a/business/src/main/java/com/example/eumserver/domain/team/TeamService.java
+++ b/business/src/main/java/com/example/eumserver/domain/team/TeamService.java
@@ -37,8 +37,10 @@ public class TeamService {
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         Team team = TeamMapper.INSTANCE.teamRequestToTeam(teamRequest);
-        String uploadUrl = s3Uploader.uploadToS3(S3Uploader.S3Path.TEAM_IMAGE, logo);
-        team.setLogo(uploadUrl);
+        if (logo != null) {
+            String uploadUrl = s3Uploader.uploadToS3(S3Uploader.S3Path.TEAM_IMAGE, logo);
+            team.setLogo(uploadUrl);
+        }
         teamRepository.save(team);
 
         Participant participant = Participant.builder()

--- a/business/src/main/java/com/example/eumserver/global/error/CustomExceptionHandler.java
+++ b/business/src/main/java/com/example/eumserver/global/error/CustomExceptionHandler.java
@@ -16,7 +16,9 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.View;
 
 /**
  * Controller단과 Filter단에서 발생하는 모든 Exception을 Handling합니다.
@@ -25,6 +27,12 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 @Slf4j
 @RestControllerAdvice
 public class CustomExceptionHandler {
+
+    private final View error;
+
+    public CustomExceptionHandler(View error) {
+        this.error = error;
+    }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     protected ResponseEntity<ApiResult<?>> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
@@ -54,6 +62,14 @@ public class CustomExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResult<?>> handleMethodArgumentNotValidException(final MethodArgumentNotValidException e) {
         final ErrorCode errorCode = ErrorCode.INVALID_INPUT_VALUE;
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(new ApiResult<>(errorCode));
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ApiResult<?>> handleMaxUploadSizeExceededException(final MaxUploadSizeExceededException e) {
+        final ErrorCode errorCode = ErrorCode.PAYLOAD_TOO_LARGE;
         return ResponseEntity
                 .status(errorCode.getStatus())
                 .body(new ApiResult<>(errorCode));

--- a/business/src/main/java/com/example/eumserver/global/error/exception/ErrorCode.java
+++ b/business/src/main/java/com/example/eumserver/global/error/exception/ErrorCode.java
@@ -2,7 +2,6 @@ package com.example.eumserver.global.error.exception;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
@@ -15,6 +14,7 @@ public enum ErrorCode {
     METHOD_NOT_ALLOWED(405, "COMMON-004", "요청이 API가 요구하는 HTTP 메서드와 다름"),
     INTERNAL_SERVER_ERROR(500, "COMMON-005", "정의되지 않은 서버 오류 발생"),
     PAYLOAD_TOO_LARGE(413, "COMMON-006", "요청의 파일 크기가 3MB를 초과"),
+    UNSUPPORTED_MEDIA_TYPE(415, "COMMON-007", "요청의 파일 형식이 요구하는 형식과 다름."),
 
     // Auth error
     INVALID_JWT_TOKEN(401, "AUTH-001", "제공된 토큰이 유효하지 않음"),

--- a/business/src/main/java/com/example/eumserver/global/error/exception/ErrorCode.java
+++ b/business/src/main/java/com/example/eumserver/global/error/exception/ErrorCode.java
@@ -2,6 +2,7 @@ package com.example.eumserver.global.error.exception;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
@@ -13,6 +14,7 @@ public enum ErrorCode {
     PAGE_NOT_FOUND(404, "COMMON-003", "요청이 API가 요구하는 URL과 다름"),
     METHOD_NOT_ALLOWED(405, "COMMON-004", "요청이 API가 요구하는 HTTP 메서드와 다름"),
     INTERNAL_SERVER_ERROR(500, "COMMON-005", "정의되지 않은 서버 오류 발생"),
+    PAYLOAD_TOO_LARGE(413, "COMMON-006", "요청의 파일 크기가 3MB를 초과"),
 
     // Auth error
     INVALID_JWT_TOKEN(401, "AUTH-001", "제공된 토큰이 유효하지 않음"),

--- a/business/src/main/resources/application.properties
+++ b/business/src/main/resources/application.properties
@@ -2,6 +2,9 @@ spring.profiles.include=oauth
 
 spring.web.resources.add-mappings=false
 
+spring.servlet.multipart.max-file-size=3MB
+spring.servlet.multipart.max-request-size=3MB
+
 spring.datasource.url=jdbc:mysql://${DB_ENDPOINT}:3306/${DB_NAME}
 spring.datasource.username=${MYSQL_USERNAME}
 spring.datasource.password=${MYSQL_PASSWORD}
@@ -28,13 +31,16 @@ spring.mail.username=${MAIL_USERNAME}
 spring.mail.password=${MAIL_PASSWORD}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
+
 spring.data.redis.host=${REDIS_HOST}
 spring.data.redis.port=6379
 spring.data.redis.repositories.enabled=false
+
 cloud.aws.region.static=${AWS_REGION}
 cloud.aws.s3.bucket=${AWS_BUCKET}
 cloud.aws.stack.auto=false
 cloud.aws.credentials.access-key=${AWS_ACCESS_KEY}
 cloud.aws.credentials.secret-key=${AWS_SECRET_KEY}
+
 logging.level.com.example.eumserver=debug
 logging.level.org.springframework.security=trace


### PR DESCRIPTION
## Overview

팀 로고가 null일 때 S3 업로드 시도로 인해 발생하는 오류를 수정하고
팀 로고를 image/jpeg 및 image/png로 제한하며,
MultipartFile이 3MB까지 가능하도록 했습니다.

### Related Issue
Issue Number : #86, #87

## Task Details

- 팀 로고 null 일 시 오류 핸들링
- 팀 로고 형식 제한
- 팀 로고 용량 결정

## Review Requirements
