### PR TITLE
feat: 파일 크기 제한 코드 재사용을 위한 어노테이션 구현

### DIFF
--- a/business/src/main/java/com/example/eumserver/domain/team/TeamController.java
+++ b/business/src/main/java/com/example/eumserver/domain/team/TeamController.java
@@ -2,6 +2,7 @@ package com.example.eumserver.domain.team;
 
 import com.example.eumserver.domain.jwt.PrincipalDetails;
 import com.example.eumserver.domain.team.dto.TeamRequest;
+import com.example.eumserver.global.annotation.MaxFileSize;
 import com.example.eumserver.global.dto.ApiResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -18,11 +19,14 @@ public class TeamController {
 
     private final TeamService teamService;
 
+    private static final int MAX_TEAM_LOGO_SIZE = 3 * 1024 * 1024; // 3MB
+
+    @MaxFileSize(value = MAX_TEAM_LOGO_SIZE)
     @PostMapping(value = "", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @ResponseStatus(HttpStatus.CREATED)
     public ResponseEntity<ApiResult<Team>> createTeam(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
-            @RequestPart(name = "logo", required = false) MultipartFile logo,
+            @RequestPart(name = "file", required = false) MultipartFile logo,
             @RequestPart(name = "json") TeamRequest teamRequest) {
         Team team = teamService.createTeam(principalDetails.getUserId(), teamRequest, logo);
         return ResponseEntity

--- a/business/src/main/java/com/example/eumserver/global/annotation/MaxFileSize.java
+++ b/business/src/main/java/com/example/eumserver/global/annotation/MaxFileSize.java
@@ -1,0 +1,20 @@
+package com.example.eumserver.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 업로드되는 파일의 최대 용량(bytes)을 설정합니다.
+ * RequestPart의 이름을 file로 설정해야 적용됩니다.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MaxFileSize {
+
+    /**
+     * 바이트 단위의 파일 최대 용량
+     */
+    long value();
+}

--- a/business/src/main/java/com/example/eumserver/global/config/WebConfig.java
+++ b/business/src/main/java/com/example/eumserver/global/config/WebConfig.java
@@ -1,7 +1,9 @@
 package com.example.eumserver.global.config;
 
+import com.example.eumserver.global.interceptor.MaxFileSizeInterceptor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
@@ -14,5 +16,10 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedMethods("GET", "POST", "DELETE", "PUT", "PATCH", "OPTIONS")
                 .allowCredentials(true);
 
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new MaxFileSizeInterceptor());
     }
 }

--- a/business/src/main/java/com/example/eumserver/global/interceptor/MaxFileSizeInterceptor.java
+++ b/business/src/main/java/com/example/eumserver/global/interceptor/MaxFileSizeInterceptor.java
@@ -1,0 +1,42 @@
+package com.example.eumserver.global.interceptor;
+
+import com.example.eumserver.global.annotation.MaxFileSize;
+import com.example.eumserver.global.dto.ApiResult;
+import com.example.eumserver.global.error.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.Nonnull;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.multipart.MultipartHttpServletRequest;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+public class MaxFileSizeInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(
+            @Nonnull HttpServletRequest request,
+            @Nonnull HttpServletResponse response,
+            @Nonnull Object handler) throws Exception {
+        if (handler instanceof HandlerMethod handlerMethod) {
+            MaxFileSize annotation = handlerMethod.getMethodAnnotation(MaxFileSize.class);
+            if (annotation != null) {
+                long maxSize = annotation.value();
+                MultipartFile file = ((MultipartHttpServletRequest) request).getFile("file"); // 파일 파라미터 이름에 맞게 수정
+                if (file != null && file.getSize() > maxSize) {
+                    ErrorCode errorCode = ErrorCode.PAYLOAD_TOO_LARGE;
+                    response.setHeader("Content-Type", "application/json;charset=utf-8");
+                    response.setStatus(errorCode.getStatus());
+
+                    ApiResult<?> apiResult = new ApiResult<>(errorCode);
+                    String json = new ObjectMapper().writeValueAsString(apiResult);
+                    response.getWriter().write(json);
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+}

--- a/business/src/main/java/com/example/eumserver/global/utils/S3Uploader.java
+++ b/business/src/main/java/com/example/eumserver/global/utils/S3Uploader.java
@@ -73,7 +73,8 @@ public class S3Uploader {
     }
     
     public enum S3Path {
-        TEAM_IMAGE("teams");
+        TEAM_IMAGE("teams"),
+        RESUME_FILE("resumes");
 
         final String path;
 

--- a/business/src/main/resources/application.properties
+++ b/business/src/main/resources/application.properties
@@ -2,8 +2,8 @@ spring.profiles.include=oauth
 
 spring.web.resources.add-mappings=false
 
-spring.servlet.multipart.max-file-size=3MB
-spring.servlet.multipart.max-request-size=3MB
+spring.servlet.multipart.max-file-size=30MB
+spring.servlet.multipart.max-request-size=30MB
 
 spring.datasource.url=jdbc:mysql://${DB_ENDPOINT}:3306/${DB_NAME}
 spring.datasource.username=${MYSQL_USERNAME}


### PR DESCRIPTION
## Overview

이력서에서 여러 파일을 받기 위해서 상한선을 30MB로 뚫고
file size를 제한하는 annotation을 만들었습니다.

### Related Issue
Issue Number : 

## Task Details

- 파일 사이즈 제한 annotation 만들기
- 해당 annotation 받는 interceptor 만들기

## Review Requirements

해당 annotation이 잘 작동하는지 확인을 못했습니다..