### PR TITLE
feat: 팀 참가자 정보 조회 구현 (#111)

### DIFF
--- a/business/src/main/java/com/example/eumserver/domain/team/TeamController.java
+++ b/business/src/main/java/com/example/eumserver/domain/team/TeamController.java
@@ -2,6 +2,8 @@ package com.example.eumserver.domain.team;
 
 import com.example.eumserver.domain.jwt.PrincipalDetails;
 import com.example.eumserver.domain.team.dto.TeamRequest;
+import com.example.eumserver.domain.team.participant.ParticipantService;
+import com.example.eumserver.domain.user.dto.UserResponse;
 import com.example.eumserver.global.annotation.MaxFileSize;
 import com.example.eumserver.global.dto.ApiResult;
 import lombok.RequiredArgsConstructor;
@@ -12,12 +14,15 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/team")
 @RequiredArgsConstructor
 public class TeamController {
 
     private final TeamService teamService;
+    private final ParticipantService participantService;
 
     private static final int MAX_TEAM_LOGO_SIZE = 3 * 1024 * 1024; // 3MB
 
@@ -53,6 +58,14 @@ public class TeamController {
         return ResponseEntity
                 .status(HttpStatus.ACCEPTED)
                 .body(new ApiResult<>("팀 삭제 성공"));
+    }
+
+    @GetMapping("/{teamId}/participant")
+    public ResponseEntity<ApiResult<List<UserResponse>>> getAllParticipant(
+            @PathVariable long teamId
+    ) {
+        List<UserResponse> userResponses = participantService.getAllParticipantByTeamId(teamId);
+        return ResponseEntity.ok(new ApiResult<>("팀 참가자 조회 성공", userResponses));
     }
 
 }

--- a/business/src/main/java/com/example/eumserver/domain/team/participant/ParticipantRepository.java
+++ b/business/src/main/java/com/example/eumserver/domain/team/participant/ParticipantRepository.java
@@ -1,6 +1,12 @@
 package com.example.eumserver.domain.team.participant;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface ParticipantRepository extends JpaRepository<Participant, ParticipantId> {
+
+    @Query("select p from Participant p join User u on p.user.id = u.id where p.team.id = :teamId")
+    List<Participant> findAllByTeamId(long teamId);
 }

--- a/business/src/main/java/com/example/eumserver/domain/team/participant/ParticipantService.java
+++ b/business/src/main/java/com/example/eumserver/domain/team/participant/ParticipantService.java
@@ -1,0 +1,27 @@
+package com.example.eumserver.domain.team.participant;
+
+import com.example.eumserver.domain.user.UserMapper;
+import com.example.eumserver.domain.user.domain.User;
+import com.example.eumserver.domain.user.dto.UserResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ParticipantService {
+
+    private final ParticipantRepository participantRepository;
+
+    public List<UserResponse> getAllParticipantByTeamId(long teamId) {
+        List<Participant> participants = participantRepository.findAllByTeamId(teamId);
+        return participants.stream().map(participant -> {
+            User user = participant.getUser();
+            return UserMapper.INSTANCE.userToUserResponse(user);
+        }).toList();
+    }
+
+}


### PR DESCRIPTION
## Overview

팀 참가자 정보 조회 구현했습니다. UserResponse와 정보는 동일합니다.

### Related Issue
Issue Number : #111

## Task Details

- Participant 조회 쿼리 생성
- ParticipantService 제작
- /team/{teamId}/participant endpoint 생성

## Review Requirements
